### PR TITLE
Fix/filter-normal-fixtures

### DIFF
--- a/frontend/src/components/bet/DrawColumn.tsx
+++ b/frontend/src/components/bet/DrawColumn.tsx
@@ -6,6 +6,7 @@ import { colors } from '../../styles/styles';
 const DrawColumn = ({
   date,
   odds,
+  isNormal,
   disabled = false,
   selected = false,
   selectable = true,
@@ -13,6 +14,7 @@ const DrawColumn = ({
 }: {
   date: string;
   odds: string;
+  isNormal: boolean;
   disabled?: boolean;
   selected?: boolean;
   selectable?: boolean;
@@ -21,7 +23,7 @@ const DrawColumn = ({
   return (
     <View style={styles.header}>
       <View style={{ height: 32 }}>
-        <PremText order={4} centered={true} padding={12}>
+        <PremText order={4} centered={true} padding={12} color={!isNormal ? 'red' : 'white'}>
           {date}
         </PremText>
       </View>

--- a/frontend/src/components/bet/current/CurrentMatchUpBet.tsx
+++ b/frontend/src/components/bet/current/CurrentMatchUpBet.tsx
@@ -61,6 +61,7 @@ const CurrentMatchUpBet = ({ fixture, bet, setBet }: Props) => {
           date={new Date(fixture.matchDate).toDateString()}
           odds={fixture.drawOdds === 0 ? 'x.xx' : fixture.drawOdds.toFixed(2)}
           disabled={!betSlice.notFound}
+          isNormal={fixture.isNormal}
           onPress={() => handlePress(FixtureResult.DRAW)}
         />
         <TeamColumn

--- a/frontend/src/components/bet/future/FutureMatchUp.tsx
+++ b/frontend/src/components/bet/future/FutureMatchUp.tsx
@@ -25,6 +25,7 @@ const FutureMatchUp = ({ fixture }: Props) => {
           disabled={true}
           date={new Date(fixture.matchDate).toDateString()}
           odds={fixture.drawOdds === 0 ? 'x.xx' : fixture.drawOdds.toFixed(2)}
+          isNormal={fixture.isNormal}
         />
         <TeamColumn
           selectable={false}

--- a/frontend/src/components/bet/past/PastMatchUp.tsx
+++ b/frontend/src/components/bet/past/PastMatchUp.tsx
@@ -34,6 +34,7 @@ const PastMatchUp = ({ fixture, bet }: Props) => {
           disabled={true}
           date={new Date(fixture.matchDate).toDateString()}
           odds={fixture.drawOdds === 0 ? 'x.xx' : fixture.drawOdds.toFixed(2)}
+          isNormal={fixture.isNormal}
         />
         <TeamColumn
           selected={

--- a/frontend/src/redux/reducers/fixtureReducer.ts
+++ b/frontend/src/redux/reducers/fixtureReducer.ts
@@ -4,7 +4,6 @@ import Fixture from '../../types/Fixture';
 import { backend } from '../../utils/constants';
 
 export interface FixtureState {
-  //   gameweeks: Gameweek[];
   fixtures: Fixture[];
   selectedGameweek: number;
   isLoading: boolean;
@@ -48,6 +47,9 @@ export const getFixtures = createAsyncThunk<Fixture[], number>(
     }
 
     const fixtures: Fixture[] = await response.json();
+    console.log(`GW${gameweek}`);
+    console.log(`normal: ${fixtures.filter((f) => f.isNormal).length}`);
+    console.log(`!normal: ${fixtures.filter((f) => !f.isNormal).length}`);
     return fixtures;
   }
 );

--- a/frontend/src/redux/reducers/fixtureReducer.ts
+++ b/frontend/src/redux/reducers/fixtureReducer.ts
@@ -47,10 +47,9 @@ export const getFixtures = createAsyncThunk<Fixture[], number>(
     }
 
     const fixtures: Fixture[] = await response.json();
-    console.log(`GW${gameweek}`);
-    console.log(`normal: ${fixtures.filter((f) => f.isNormal).length}`);
-    console.log(`!normal: ${fixtures.filter((f) => !f.isNormal).length}`);
-    return fixtures;
+    // only use normal fixtures
+    const normalFixtures = fixtures.filter((f) => f.isNormal);
+    return normalFixtures;
   }
 );
 

--- a/frontend/src/types/Fixture.ts
+++ b/frontend/src/types/Fixture.ts
@@ -19,4 +19,5 @@ export default interface Fixture {
   homeOdds: number;
   drawOdds: number;
   awayOdds: number;
+  isNormal: boolean;
 }

--- a/server/controllers/bets.go
+++ b/server/controllers/bets.go
@@ -120,14 +120,14 @@ func PlaceMyBetForGameweek(c *gin.Context) {
 		return
 	}
 
-	fixturesForGW, err := repositories.FetchFixturesByGameweek(gameweek)
+	fixturesForGW, err := repositories.FetchNormalFixturesByGameweek(gameweek)
 	if err != nil {
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Internal error while fetching fixtures for gameweek %d", gameweek)})
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Internal error while fetching normal fixtures for gameweek %d", gameweek)})
 		return
 	}
 
 	if len(body.Bets) != len(fixturesForGW) {
-		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("number of bets provided does not match fixtures in GW%d (%d provided, %d needed)", gameweek, len(body.Bets), len(fixturesForGW))})
+		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("number of bets provided does not match normal fixtures in GW%d (%d provided, %d needed)", gameweek, len(body.Bets), len(fixturesForGW))})
 		return
 	}
 
@@ -163,6 +163,7 @@ func PlaceMyBetForGameweek(c *gin.Context) {
 				betFixtureFound = true
 				createdBet := CreateBet(betFixture, user.ID, gameweek)
 				bets = append(bets, createdBet)
+				break // fixture already matched, no need to continue searching
 			}
 		}
 

--- a/server/controllers/fixtures.go
+++ b/server/controllers/fixtures.go
@@ -24,7 +24,7 @@ func GetFixtureByGameWeek(c *gin.Context) {
 
 	gw := uint8(gameweekInt)
 
-	fixtures, err := repositories.FetchFixturesByGameweek(gw)
+	fixtures, err := repositories.FetchNormalFixturesByGameweek(gw)
 
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/server/crons/AssignOdds.go
+++ b/server/crons/AssignOdds.go
@@ -1,0 +1,40 @@
+package crons
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/kristo-og-logi/premKing/server/initializers"
+	"github.com/kristo-og-logi/premKing/server/models"
+)
+
+func AssignOdds(dbFixture models.Fixture, jsonFixture models.SportmonksFixture) (updated bool) {
+	updated = false
+	// no need to reassign odds
+	if dbFixture.AwayOdds >= 0.1 || dbFixture.HomeOdds >= 0.1 || dbFixture.DrawOdds >= 0.1 {
+		return
+	}
+	// if odds haven't appeard in API, don't update
+	if len(jsonFixture.Odds) == 0 {
+		return
+	}
+
+	var homeOdd, drawOdd, awayOdd float32
+	for _, odd := range jsonFixture.Odds {
+		if odd.OriginalLabel == "2" {
+			oddValue, _ := strconv.ParseFloat(odd.Value, 32)
+			awayOdd = float32(oddValue)
+		} else if odd.OriginalLabel == "1" {
+			oddValue, _ := strconv.ParseFloat(odd.Value, 32)
+			homeOdd = float32(oddValue)
+		} else if odd.OriginalLabel == "Draw" {
+			oddValue, _ := strconv.ParseFloat(odd.Value, 32)
+			drawOdd = float32(oddValue)
+		} else {
+			panic(fmt.Sprintf("found odd with original_label: %v\n", odd.OriginalLabel))
+		}
+	}
+	initializers.DB.Model(&dbFixture).Updates(models.Fixture{HomeOdds: homeOdd, DrawOdds: drawOdd, AwayOdds: awayOdd})
+	updated = true
+	return
+}

--- a/server/crons/ChangeGWTimes.go
+++ b/server/crons/ChangeGWTimes.go
@@ -1,0 +1,64 @@
+package crons
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/kristo-og-logi/premKing/server/initializers"
+	"github.com/kristo-og-logi/premKing/server/models"
+	"github.com/kristo-og-logi/premKing/server/repositories"
+)
+
+// ChangeGWTimes updates, if necessary, all gameweeks's
+// Opens, Closes and Finishes attributes depending on
+// whether the normal fixture matchDates changed
+func ChangeGWTimes() {
+	gws := getGWs()
+
+	opensUpdated := 0
+	closesUpdated := 0
+	finishesUpdated := 0
+	for idx := range gws {
+		fixtures, err := repositories.FetchNormalFixturesByGameweek(uint8(gws[idx].Gameweek))
+		if err != nil {
+			fmt.Printf("couldn't find fixtures for GW%d: %s", gws[idx].Gameweek, err.Error())
+			continue
+		}
+
+		if gws[idx].Closes.Compare(fixtures[0].MatchDate.Add(-2*time.Hour)) != 0 {
+			gws[idx].Closes = fixtures[0].MatchDate.Add(-2 * time.Hour)
+			closesUpdated++
+		}
+		if gws[idx].Finishes.Compare(fixtures[len(fixtures)-1].MatchDate.Add(2*time.Hour)) != 0 {
+			gws[idx].Finishes = fixtures[len(fixtures)-1].MatchDate.Add(2 * time.Hour)
+			finishesUpdated++
+
+			if idx < 37 {
+				gws[idx+1].Opens = fixtures[len(fixtures)-1].MatchDate.Add(2 * time.Hour)
+				opensUpdated++
+			}
+		}
+	}
+
+	initializers.DB.Save(&gws)
+	fmt.Printf("gw.Opens updated: %d\n", opensUpdated)
+	fmt.Printf("gw.Closes updated: %d\n", closesUpdated)
+	fmt.Printf("gw.Finishes updated: %d\n", finishesUpdated)
+}
+
+func getGWs() []models.Gameweek {
+	gws := []models.Gameweek{}
+
+	result := initializers.DB.Find(&gws)
+
+	if result.Error != nil {
+		fmt.Printf("error fetching gameweeks: %s", result.Error.Error())
+	}
+
+	sort.Slice(gws, func(i, j int) bool {
+		return gws[i].Gameweek < gws[j].Gameweek
+	})
+
+	return gws
+}

--- a/server/crons/UpdateDate.go
+++ b/server/crons/UpdateDate.go
@@ -1,0 +1,25 @@
+package crons
+
+import (
+	"time"
+
+	"github.com/kristo-og-logi/premKing/server/initializers"
+	"github.com/kristo-og-logi/premKing/server/models"
+)
+
+func UpdateDate(dbFixture models.Fixture, jsonFixture models.SportmonksFixture) (updated bool) {
+	updated = false
+
+	jsonTime, err := time.Parse("2006-01-02 15:04:05", jsonFixture.StartingAt)
+	if err != nil {
+		// fmt.Printf("err - %s\n", err.Error())
+		return
+	}
+
+	if jsonTime.Compare(dbFixture.MatchDate) != 0 {
+		// fmt.Printf("%s | from %s to %s\n", dbFixture.Name, dbFixture.MatchDate, jsonTime)
+		initializers.DB.Model(&dbFixture).Updates(models.Fixture{MatchDate: jsonTime})
+		updated = true
+	}
+	return
+}

--- a/server/crons/UpdateStatusAndScores.go
+++ b/server/crons/UpdateStatusAndScores.go
@@ -1,0 +1,40 @@
+package crons
+
+import (
+	"fmt"
+
+	"github.com/kristo-og-logi/premKing/server/initializers"
+	"github.com/kristo-og-logi/premKing/server/models"
+)
+
+func UpdateStatusAndScores(dbFixture models.Fixture, jsonFixture models.SportmonksFixture) (updated bool) {
+	updated = false
+
+	if jsonFixture.State == "FT" && !dbFixture.Finished {
+
+		result := ""
+		if jsonFixture.Score.Home > jsonFixture.Score.Away {
+			result = "1"
+		} else if jsonFixture.Score.Home < jsonFixture.Score.Away {
+			result = "2"
+		} else {
+			result = "X"
+		}
+
+		response := initializers.DB.Model(&dbFixture).Select("Finished", "Result", "AwayGoals", "HomeGoals").Updates(models.Fixture{
+			Finished:  true,
+			HomeGoals: uint8(jsonFixture.Score.Home),
+			AwayGoals: uint8(jsonFixture.Score.Away),
+			Result:    result,
+		})
+
+		if response.Error != nil {
+			fmt.Printf("error saving new status and score to fixture: %s", response.Error.Error())
+			return
+		}
+
+		updated = true
+	}
+
+	return
+}

--- a/server/crons/main.go
+++ b/server/crons/main.go
@@ -1,0 +1,16 @@
+package crons
+
+import (
+	"fmt"
+
+	"github.com/robfig/cron/v3"
+)
+
+func CRON() {
+	fmt.Println("adding cron...")
+	c := cron.New()
+	// every function added to a cronjob runs in a separate goroutine,
+	// no need to do anything here
+	c.AddFunc("0 * * * *", UpdateFixtures)
+	c.Start()
+}

--- a/server/main.go
+++ b/server/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/go-playground/validator/v10"
+	"github.com/kristo-og-logi/premKing/server/crons"
 	"github.com/kristo-og-logi/premKing/server/initializers"
 	"github.com/kristo-og-logi/premKing/server/routes"
 )
@@ -14,7 +15,7 @@ import (
 func init() {
 	initializers.LoadEnv()
 	initializers.ConnectDB()
-	initializers.CRON()
+	crons.CRON()
 }
 
 func main() {

--- a/server/maintenance/maintenance.go
+++ b/server/maintenance/maintenance.go
@@ -18,20 +18,24 @@ func main() {
 	initializers.ConnectDB()
 
 	// AddOddsAndWonToBets()
-	// CreateBets()
+	CreateBets()
 	// FindAndSaveNormalFixtures()
-	ChangeGWTimes()
+	// ChangeGWTimes()
 }
 
 func CreateBets() {
 	fmt.Print("email: ")
 	userEmail, _, _ := bufio.NewReader(os.Stdin).ReadLine()
 
+	fmt.Print("bet (1 | X | 2): ")
+	userGuess, _, _ := bufio.NewReader(os.Stdin).ReadLine()
+
 	user := getUser(string(userEmail))
+	guess := string(userGuess)
 
 	for gw := 1; gw < 36; gw++ {
-		fixtures := getFixturesByGW(gw)
-		bets := createBets(user, fixtures, "1")
+		fixtures := getNormalFixturesByGW(gw)
+		bets := createBets(user, fixtures, guess)
 		saveBets(bets)
 	}
 
@@ -253,13 +257,11 @@ func saveBets(bets []models.Bet) {
 	}
 }
 
-func getFixturesByGW(gw int) (fixtures []models.Fixture) {
-	fixtures = []models.Fixture{}
-
-	result := initializers.DB.Find(&fixtures, "game_week = ?", gw)
-	if result.Error != nil {
-		fmt.Printf("error fetching fixtures with gw %d: %s", gw, result.Error.Error())
-		return nil
+func getNormalFixturesByGW(gw int) []models.Fixture {
+	fixtures, err := repositories.FetchNormalFixturesByGameweek(uint8(gw))
+	if err != nil {
+		fmt.Printf("error fetching normal fixtures for GW%d\n", gw)
+		os.Exit(1)
 	}
 
 	return fixtures

--- a/server/maintenance/maintenance.go
+++ b/server/maintenance/maintenance.go
@@ -2,15 +2,15 @@ package main
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/kristo-og-logi/premKing/server/initializers"
 	"github.com/kristo-og-logi/premKing/server/models"
+	"github.com/kristo-og-logi/premKing/server/repositories"
 )
 
 func main() {
@@ -18,7 +18,9 @@ func main() {
 	initializers.ConnectDB()
 
 	// AddOddsAndWonToBets()
-	CreateBets()
+	// CreateBets()
+	// FindAndSaveNormalFixtures()
+	ChangeGWTimes()
 }
 
 func CreateBets() {
@@ -36,28 +38,6 @@ func CreateBets() {
 	fmt.Println("all bets saved :)")
 }
 
-func UpdateFixturesFromAPI() {
-	dbFixtures := getFixturesFromDB()
-	jsonFixtures := getJSONFixturesFromFile()
-
-	totalUpdated := 0
-	for _, dbfix := range dbFixtures {
-		for _, jsonfix := range jsonFixtures {
-			if dbfix.Name == jsonfix.Name {
-				updated := false
-				updated = assignOdds(dbfix, jsonfix) || updated
-				updated = updateDate(dbfix, jsonfix) || updated
-
-				if updated {
-					totalUpdated++
-				}
-				break
-			}
-		}
-	}
-	fmt.Printf("Updated %d rows\n", totalUpdated)
-}
-
 func AddOddsAndWonToBets() {
 	allBets := getAllNonUpdatedBets()
 	allFixtures := getAllPastFixtures()
@@ -66,6 +46,98 @@ func AddOddsAndWonToBets() {
 	fmt.Printf("found %d fixtures\n", len(allFixtures))
 
 	updateOddsAndWon(allFixtures, allBets)
+}
+
+// ChangeGWTimes updates, if necessary, all gameweeks's
+// Opens, Closes and Finishes attributes depending on
+// whether the normal fixture matchDates changed
+func ChangeGWTimes() {
+	gws := getGWs()
+
+	opensUpdated := 0
+	closesUpdated := 0
+	finishesUpdated := 0
+	for idx := range gws {
+		fixtures, err := repositories.FetchNormalFixturesByGameweek(uint8(gws[idx].Gameweek))
+		if err != nil {
+			fmt.Printf("couldn't find fixtures for GW%d: %s", gws[idx].Gameweek, err.Error())
+			continue
+		}
+
+		if gws[idx].Closes.Compare(fixtures[0].MatchDate.Add(-2*time.Hour)) != 0 {
+			gws[idx].Closes = fixtures[0].MatchDate.Add(-2 * time.Hour)
+			closesUpdated++
+		}
+		if gws[idx].Finishes.Compare(fixtures[len(fixtures)-1].MatchDate.Add(2*time.Hour)) != 0 {
+			gws[idx].Finishes = fixtures[len(fixtures)-1].MatchDate.Add(2 * time.Hour)
+			finishesUpdated++
+
+			if idx < 37 {
+				gws[idx+1].Opens = fixtures[len(fixtures)-1].MatchDate.Add(2 * time.Hour)
+				opensUpdated++
+			}
+		}
+	}
+
+	initializers.DB.Save(&gws)
+	fmt.Printf("gw.Opens updated: %d\n", opensUpdated)
+	fmt.Printf("gw.Closes updated: %d\n", closesUpdated)
+	fmt.Printf("gw.Finishes updated: %d\n", finishesUpdated)
+}
+
+// FindNormalFixtures groups and saves all fixtures
+// by their gameweek, and finds out which are normal
+// , meaning that they occur within the gameweek's timeframe.
+func FindAndSaveNormalFixtures() {
+	fixtureList := make([][]models.Fixture, 38)
+
+	for gw := 1; gw <= 38; gw++ {
+		fixtures, err := repositories.FetchFixturesByGameweek(uint8(gw))
+		if err != nil {
+			fmt.Printf("couldn't find fixtures for GW%d: %s", gw, err.Error())
+			continue
+		}
+
+		fixtureList[gw-1] = fixtures
+	}
+
+	for gw := 1; gw <= 38; gw++ {
+		fmt.Printf("GW%d\n", gw)
+		fixtures := fixtureList[gw-1]
+
+		for idx, fix := range fixtures {
+			isNormal := false
+			if fix.GameWeek == 38 || fix.MatchDate.Sub(fixtureList[gw][0].MatchDate).Hours() <= 48 {
+				isNormal = true
+			}
+
+			fmt.Printf("	%v", fix.MatchDate.Format("2006-01-02 15:04"))
+
+			if isNormal {
+				fmt.Println(" - X")
+				fixtures[idx].IsNormal = true
+			} else {
+				fmt.Println()
+			}
+		}
+		initializers.DB.Save(&fixtures)
+	}
+}
+
+func getGWs() []models.Gameweek {
+	gws := []models.Gameweek{}
+
+	result := initializers.DB.Find(&gws)
+
+	if result.Error != nil {
+		fmt.Printf("error fetching gameweeks: %s", result.Error.Error())
+	}
+
+	sort.Slice(gws, func(i, j int) bool {
+		return gws[i].Gameweek < gws[j].Gameweek
+	})
+
+	return gws
 }
 
 func updateOddsAndWon(fx []models.Fixture, bts []models.Bet) {
@@ -177,7 +249,7 @@ func createBets(user *models.User, fixtures []models.Fixture, result string) []m
 func saveBets(bets []models.Bet) {
 	result := initializers.DB.Save(&bets)
 	if result.Error != nil {
-		fmt.Printf("error saving bet: %s", result.Error.Error())
+		fmt.Printf("error saving bets: %s", result.Error.Error())
 	}
 }
 
@@ -191,89 +263,4 @@ func getFixturesByGW(gw int) (fixtures []models.Fixture) {
 	}
 
 	return fixtures
-}
-
-func updateDate(dbFixture models.Fixture, jsonFixture models.SportmonksFixture) (updated bool) {
-	updated = false
-
-	jsonTime, err := time.Parse("2006-01-02 15:04:05", jsonFixture.StartingAt)
-	if err != nil {
-		// fmt.Printf("err - %s\n", err.Error())
-		return
-	}
-
-	if jsonTime.Compare(dbFixture.MatchDate) != 0 {
-		// fmt.Printf("%s | from %s to %s\n", dbFixture.Name, dbFixture.MatchDate, jsonTime)
-		initializers.DB.Model(&dbFixture).Updates(models.Fixture{MatchDate: jsonTime})
-		updated = true
-	}
-	return
-}
-
-func assignOdds(dbFixture models.Fixture, jsonFixture models.SportmonksFixture) (updated bool) {
-	updated = false
-	// no need to reassign odds
-	if dbFixture.AwayOdds >= 0.1 || dbFixture.HomeOdds >= 0.1 || dbFixture.DrawOdds >= 0.1 {
-		return
-	}
-	// if odds haven't appeard in API, don't update
-	if len(jsonFixture.Odds) == 0 {
-		return
-	}
-
-	var homeOdd, drawOdd, awayOdd float32
-	for _, odd := range jsonFixture.Odds {
-		if odd.OriginalLabel == "2" {
-			oddValue, _ := strconv.ParseFloat(odd.Value, 32)
-			awayOdd = float32(oddValue)
-		} else if odd.OriginalLabel == "1" {
-			oddValue, _ := strconv.ParseFloat(odd.Value, 32)
-			homeOdd = float32(oddValue)
-		} else if odd.OriginalLabel == "Draw" {
-			oddValue, _ := strconv.ParseFloat(odd.Value, 32)
-			drawOdd = float32(oddValue)
-		} else {
-			panic(fmt.Sprintf("found odd with original_label: %v\n", odd.OriginalLabel))
-		}
-	}
-	initializers.DB.Model(&dbFixture).Updates(models.Fixture{HomeOdds: homeOdd, DrawOdds: drawOdd, AwayOdds: awayOdd})
-	updated = true
-	return
-}
-
-func AssignId(dbFixture models.Fixture, jsonFixture models.SportmonksFixture) {
-	initializers.DB.Model(&dbFixture).Updates(models.Fixture{SportmonksID: jsonFixture.Id})
-}
-
-func getFixturesFromDB() []models.Fixture {
-	fixtures := []models.Fixture{}
-	result := initializers.DB.Find(&fixtures)
-	if result.Error != nil {
-		fmt.Printf("error: %s\n", result.Error.Error())
-		os.Exit(1)
-	}
-
-	fmt.Printf("found %d fixtures!\n", len(fixtures))
-
-	return fixtures
-}
-
-func getJSONFixturesFromFile() []models.SportmonksFixture {
-	// ensure that pages.json exists
-	// - it might have to be created by saveFixtures.py in the same directory
-	jsonFile, err := os.ReadFile("json/sportmonks/fixtures/pages.json")
-	if err != nil {
-		fmt.Printf("error reading json file: %s\n", err.Error())
-		os.Exit(1)
-	}
-
-	jsonFixtures := []models.SportmonksFixture{}
-
-	err = json.Unmarshal(jsonFile, &jsonFixtures)
-	if err != nil {
-		fmt.Printf("error unmarshalling json to fixtures: %s\n", err.Error())
-		os.Exit(1)
-	}
-
-	return jsonFixtures
 }

--- a/server/models/Fixture.go
+++ b/server/models/Fixture.go
@@ -24,6 +24,7 @@ type Fixture struct {
 	Name         string    `json:"name"`
 	LongName     string    `json:"longName"`
 	SportmonksID uint32    `gorm:"unique" json:"sportmonksId"`
+	IsNormal     bool      `json:"isNormal"`
 }
 
 type FixturesResponse struct {

--- a/server/repositories/fixtures.go
+++ b/server/repositories/fixtures.go
@@ -1,6 +1,8 @@
 package repositories
 
 import (
+	"sort"
+
 	"github.com/kristo-og-logi/premKing/server/initializers"
 	"github.com/kristo-og-logi/premKing/server/models"
 )
@@ -12,6 +14,22 @@ func FetchFixturesByGameweek(gw uint8) ([]models.Fixture, error) {
 	if result.Error != nil {
 		return nil, result.Error
 	}
+
+	return fixtures, nil
+}
+
+func FetchNormalFixturesByGameweek(gw uint8) ([]models.Fixture, error) {
+	fixtures := []models.Fixture{}
+
+	result := initializers.DB.Preload("HomeTeam").Preload("AwayTeam").Order("match_date ASC").Find(&fixtures, "game_week = ? AND is_normal = true", gw)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	// sort fixtures by their matchDate
+	sort.Slice(fixtures, func(i, j int) bool {
+		return fixtures[i].MatchDate.Before(fixtures[j].MatchDate)
+	})
 
 	return fixtures, nil
 }


### PR DESCRIPTION
Not all fixtures take place on their given gameweek.
Bets should not be altered by these gameweeks, and therefore, non-normal fixtures should not appear within that bet.

In this PR, fixtures are categorized as normal or not normal. A fixture is normal if it takes place at the latest 48 hrs before the first fixture in the next gameweek. This works as non-normal fixtures seem to only be delayed, not rushed.

Also, created a maintenance function which updates a Gameweek's Open, Closes & Finishes attributes based on the normal fixture range. 