### PR TITLE
Fix/create or join league

### DIFF
--- a/frontend/src/components/leagueMenu/LeagueItem.tsx
+++ b/frontend/src/components/leagueMenu/LeagueItem.tsx
@@ -45,7 +45,7 @@ const LeagueItem = ({ league, gw, onPress }: Props) => {
               <View style={styles.memberPosition}>
                 <PremText order={4}>position</PremText>
                 <PremText>
-                  {leagueSlice.isLoading ? '...' : league.position[gw - 1].position}
+                  {leagueSlice.isLoading ? '...' : league.position[gw - 1]?.position || 'x'}
                 </PremText>
               </View>
             </View>

--- a/server/controllers/leagues.go
+++ b/server/controllers/leagues.go
@@ -151,5 +151,15 @@ func JoinLeague(c *gin.Context) {
 		return
 	}
 
-	c.IndentedJSON(http.StatusOK, league)
+	users := CalculateUsersWithScoresAndPosition(*league)
+
+	leagueDTO := LeagueDTO{
+		Id:       league.ID,
+		Name:     league.Name,
+		OwnerId:  league.OwnerID,
+		Members:  len(users),
+		Position: calculatePositions(users, currentUser.ID),
+	}
+
+	c.IndentedJSON(http.StatusOK, leagueDTO)
 }

--- a/server/controllers/users.go
+++ b/server/controllers/users.go
@@ -159,7 +159,7 @@ func UserExistsById(id string) (bool, error) {
 	return true, nil
 }
 
-type MyLeaguesResponse struct {
+type LeagueDTO struct {
 	Id       string        `json:"id"`
 	Name     string        `json:"name"`
 	OwnerId  string        `json:"ownerId"`
@@ -184,10 +184,10 @@ func GetMyLeagues(c *gin.Context) {
 		return
 	}
 
-	resp := []MyLeaguesResponse{}
+	resp := []LeagueDTO{}
 	for _, l := range leagues {
 		users := CalculateUsersWithScoresAndPosition(l)
-		leagueResp := MyLeaguesResponse{
+		leagueResp := LeagueDTO{
 			Id:       l.ID,
 			Name:     l.Name,
 			OwnerId:  l.OwnerID,
@@ -245,10 +245,20 @@ func CreateMyLeague(c *gin.Context) {
 
 	league, err := repositories.CreateleagueFromOwnerId(body.LeagueName, currentUser.ID)
 
+	users := CalculateUsersWithScoresAndPosition(*league)
+
+	leagueDTO := LeagueDTO{
+		Id:       league.ID,
+		Name:     league.Name,
+		OwnerId:  league.OwnerID,
+		Members:  len(league.Users),
+		Position: calculatePositions(users, currentUser.ID),
+	}
+
 	if err != nil {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.IndentedJSON(http.StatusCreated, league)
+	c.IndentedJSON(http.StatusCreated, leagueDTO)
 }


### PR DESCRIPTION
creating or joining a league would not respond with the same type as getMyLeagues, causing an error when the frontend tried using the position attribute of a league object which didn't have it. A frontend change isn't necessary, so an AWS update should fix the issue.