### PR TITLE
exclude `logs/` dir from aws zip

### DIFF
--- a/server/prepareForAWS.sh
+++ b/server/prepareForAWS.sh
@@ -8,7 +8,7 @@ GOOS=linux GOARCH=amd64 go build -o awsServer
 
 rm ../aws.zip
 # zip the repository into a server.zip
-zip -r ../aws.zip * ".env.PROD" ".platform"
+zip -r ../aws.zip * ".env.PROD" ".platform" -x "logs/*"
 
 echo "New aws.zip has been created in parent directory"
 echo "You may upload it to AWS"


### PR DESCRIPTION
I don't want my local debug `logs/` dir to be shipped to aws.

Also, I want a way to save my old log dirs when booting a new version