### PR TITLE
do not dereference a null ptr

### DIFF
--- a/server/controllers/leagues.go
+++ b/server/controllers/leagues.go
@@ -144,7 +144,7 @@ func JoinLeague(c *gin.Context) {
 	}
 
 	if league == nil {
-		slog.Warn("League not found", "leagueId", league.ID)
+		slog.Warn("League not found", "leagueId", leagueId)
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("league with id %s not found", leagueId)})
 		return
 	}


### PR DESCRIPTION
affected users joining leagues that did not exist
they just got a bad error message, telling them some json stuff instead of the correct error message, that the league did not exist